### PR TITLE
GHA to update jib image with the latest version

### DIFF
--- a/.github/workflows/update-jib-base-image.yml
+++ b/.github/workflows/update-jib-base-image.yml
@@ -1,0 +1,65 @@
+name: Auto-Update Jib Base Image
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 5" # Every Friday at Midnight
+
+jobs:
+  update_build_gradle:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh
+
+      - name: Update build.gradle and create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Extract current version from JShellAPI build.gradle
+          gradle_file="JShellAPI/build.gradle"
+          current_version=$(grep -oP "(?<=from\.image\s=\s'eclipse-temurin:)\d+" $gradle_file)
+          
+          if [ -z "$current_version" ]; then
+            echo "Failed to extract version from $gradle_file \"from.image\""
+            exit 1
+          fi
+          
+          # Fetch the latest eclipse-temurin image
+          latest_version=$(curl -s "https://hub.docker.com/v2/repositories/library/eclipse-temurin/tags/?page_size=100" | \
+          jq -r '[.results[].name | select(test("^[0-9]+"))] | map(capture("^(?<major>[0-9]+)")) | max_by(.major | tonumber) | .major')
+          
+          # Check if a new version is available
+          if [ "$latest_version" -le "$current_version" ]; then
+            echo "No new versions available"
+            exit 0
+          fi
+          
+          # Update the build.gradle with the new version
+          sed -i "s/eclipse-temurin:$current_version/eclipse-temurin:$latest_version/" $gradle_file
+          
+          echo "Updated eclipse-temurin version from $current_version to $latest_version"
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          
+          branch_name="update-eclipse-temurin-$latest_version"
+          git checkout -b "$branch_name"
+          
+          git add "$gradle_file"
+          git commit -m "Update eclipse-temurin version to $latest_version"
+          
+          git fetch origin
+          git rebase origin/develop
+          git push origin "$branch_name"
+
+          gh pr create --title "Update eclipse-temurin version to $latest_version" \
+          --body "This PR updates the eclipse-temurin version in the JShellAPI build.gradle file from $current_version to $latest_version." \
+          --head "$branch_name" \
+          --base "develop"          

--- a/.github/workflows/update-jib-base-image.yml
+++ b/.github/workflows/update-jib-base-image.yml
@@ -23,7 +23,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Extract current version from JShellAPI build.gradle
-          gradle_file="JShellAPI/build.gradle"
+          gradle_file="JShellWrapper/build.gradle"
           current_version=$(grep -oP "(?<=from\.image\s=\s'eclipse-temurin:)\d+" $gradle_file)
           
           if [ -z "$current_version" ]; then
@@ -33,8 +33,9 @@ jobs:
           
           # Fetch the latest eclipse-temurin image
           latest_version=$(curl -s "https://hub.docker.com/v2/repositories/library/eclipse-temurin/tags/?page_size=100" | \
-          jq -r '[.results[].name | select(test("^[0-9]+"))] | map(capture("^(?<major>[0-9]+)")) | max_by(.major | tonumber) | .major')
-          
+          jq -r '[.results[].name | select(test("alpine")) | select(test("^[0-9]+"))] | map(capture("^(?<major>[0-9]+)")) | max_by(.major | tonumber) | .major')
+  
+  
           # Check if a new version is available
           if [ "$latest_version" -le "$current_version" ]; then
             echo "No new versions available"
@@ -42,7 +43,7 @@ jobs:
           fi
           
           # Update the build.gradle with the new version
-          sed -i "s/eclipse-temurin:$current_version/eclipse-temurin:$latest_version/" $gradle_file
+          sed -i "s/eclipse-temurin:$current_version-alpine/eclipse-temurin:$latest_version-alpine/" $gradle_file
           
           echo "Updated eclipse-temurin version from $current_version to $latest_version"
 


### PR DESCRIPTION
## Context
This PR was a request from Alatheron to auto update the jib docker image when a new update is available. 

How this works:
1. A GHA was created that is scheduled to run once a week (Friday at midnight) 
2. The GHA fetches the latest version from Docker and if a new version is available...
3. Create a new PR with the changes

**Screenshots**
![image](https://github.com/user-attachments/assets/d4d09b95-c8f0-4b75-9dbf-6c4da506b7d6)

![image](https://github.com/user-attachments/assets/dd5a5128-0883-4491-8679-b91cb02b9974)

![image](https://github.com/user-attachments/assets/32ae78cd-55af-43e4-a633-fd9e35dff2cf)

![image](https://github.com/user-attachments/assets/b011b07c-2c13-4b0b-8214-e8b0c1556020)

![image](https://github.com/user-attachments/assets/51cd9563-39dc-4ddc-8858-d58c20777d9f)
